### PR TITLE
fixed editing issues with `TypedTextFormField`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ migrate_working_dir/
 .flutter-plugins
 .flutter-plugins-dependencies
 build/
+coverage/lcov.info

--- a/lib/src/typed_text_form_field.dart
+++ b/lib/src/typed_text_form_field.dart
@@ -104,7 +104,7 @@ class _TypedTextFormFieldState<T> extends State<TypedTextFormField<T>> {
   @override
   void didUpdateWidget(covariant TypedTextFormField<T> oldWidget) {
     if (oldWidget._value != widget._value) {
-      controller.text = widget._value;
+      _updateText(widget._value);
     }
 
     super.didUpdateWidget(oldWidget);
@@ -124,6 +124,16 @@ class _TypedTextFormFieldState<T> extends State<TypedTextFormField<T>> {
       inputFormatters: widget.spec.inputFormatters,
       decoration: widget.decoration,
       keyboardType: widget.spec.keyboardType,
+    );
+  }
+
+  void _updateText(String text) {
+    if (controller.text == text) return;
+
+    controller.value = controller.value.copyWith(
+      text: text,
+      selection: TextSelection.fromPosition(TextPosition(offset: text.length)),
+      composing: TextRange.empty,
     );
   }
 }

--- a/test/src/typed_text_form_field_test.dart
+++ b/test/src/typed_text_form_field_test.dart
@@ -1,0 +1,93 @@
+import 'package:data_widgets/data_widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('TypedTextFormField', () {
+    final ValueNotifier<String> source = ValueNotifier('');
+
+    Widget buildForString() {
+      return MaterialApp(
+        home: Scaffold(
+          body: ListenableBuilder(
+            listenable: source,
+            builder:
+                (context, _) => TypedTextFormField(
+                  source: source.value,
+                  onChanged: (value) {
+                    source.value = value;
+                  },
+                  spec: TypedTextFormFieldSpec<String>(
+                    serialize: (x) => x ?? '',
+                    deserialize: (x) => x,
+                    inputFormatters: [],
+                    keyboardType: TextInputType.text,
+                  ),
+                ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('should show the text', (tester) async {
+      await tester.pumpWidget(buildForString());
+      await tester.enterText(find.byType(TextField), 'test');
+      expect(source.value, equals('test'));
+    });
+
+    testWidgets('can edit from other cursor positions', (tester) async {
+      await tester.pumpWidget(buildForString());
+
+      final controller =
+          tester.widget<TextField>(find.byType(TextField)).controller!;
+
+      await tester.showKeyboard(find.byType(TextField));
+
+      // Simulate a user adding foo to bar from the beginning
+      tester.testTextInput.updateEditingValue(
+        controller.value.copyWith(
+          text: 'foobar',
+          selection: TextSelection.collapsed(offset: 3),
+        ),
+      );
+
+      await tester.pump();
+
+      expect(controller.text, equals('foobar'));
+      expect(controller.selection.start, equals(3));
+      expect(controller.selection.end, equals(3));
+      expect(source.value, equals('foobar'));
+    });
+    testWidgets('cannot enter invalid composing range', (tester) async {
+      await tester.pumpWidget(buildForString());
+
+      await tester.showKeyboard(find.byType(TextField));
+
+      // Enter text to create an invalid composing range
+      tester.testTextInput.updateEditingValue(
+        const TextEditingValue(
+          text: 'foobar',
+          selection: TextSelection.collapsed(offset: 2),
+          composing: TextRange(start: 1, end: 2),
+        ),
+      );
+
+      await tester.pump();
+
+      // verify that the composing range on the text field is valid
+      final backingTextField = tester.widget<TextField>(find.byType(TextField));
+      final controller = backingTextField.controller!;
+      expect(controller.value.composing.start, 1);
+      expect(controller.value.composing.end, 2);
+
+      // Set the new value externally (not by user)
+      source.value = '';
+      await tester.pump();
+
+      // Verify that the composing range is cleared
+      expect(controller.value.composing, TextRange.empty);
+
+      expect(find.byType(TextField), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
The text updating mechanism was incomplete: Try moving the cursor to somewhere in the middle of the text and typing something before this change, the cursor will always jump to the end.

Fixes #1 